### PR TITLE
Use `exist?` instead of `exists?` removed in 3.2

### DIFF
--- a/modules/ruby-env/gen-bin-stubs.rb
+++ b/modules/ruby-env/gen-bin-stubs.rb
@@ -58,7 +58,7 @@ def bundler_setup!
   Bundler.setup(#{groups.map(&:dump).join(', ')})
 end
 
-if File.exists? "\#{Dir.pwd}/Gemfile"
+if File.exist? "\#{Dir.pwd}/Gemfile"
    bundler_setup!
 end
 


### PR DESCRIPTION
`File.exists?` was removed by https://github.com/ruby/ruby/pull/5352. This results in error on Ruby 3.2