### PR TITLE
Separate bundix

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,5 +1,3 @@
-bundix:
-
 { stdenv, lib, buildEnv, ruby, makeBinaryWrapper, defaultGemConfig, buildRubyGem
 , ... }@pkgs:
 
@@ -18,7 +16,7 @@ let
   bundler = pkgs.bundler.override { inherit ruby; };
 
   requirements = (pkgs // {
-    inherit my name ruby bundler bundix gempaths gemConfig groups document
+    inherit my name ruby bundler gempaths gemConfig groups document
       extraRubySetup;
     gemset = if builtins.typeOf gemset == "set" then
       gemset

--- a/examples/simple-app/flake.nix
+++ b/examples/simple-app/flake.nix
@@ -10,6 +10,11 @@
   inputs = {
     nixpkgs.url = "nixpkgs";
     ruby-nix.url = "github:sagittaros/ruby-nix";
+    # a fork that supports platform dependant gem
+    bundix = {
+      url = "github:sagittaros/bundix/main";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
     fu.url = "github:numtide/flake-utils";
     bob-ruby.url = "github:bobvanderlinden/nixpkgs-ruby";
     bob-ruby.inputs.nixpkgs.follows = "nixpkgs";

--- a/examples/simple-app/flake.nix
+++ b/examples/simple-app/flake.nix
@@ -2,9 +2,9 @@
   description = "A simple ruby app demo";
 
   nixConfig = {
-    substituters = "https://cache.nixos.org https://nixpkgs-ruby.cachix.org";
-    trusted-public-keys =
-      "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= nixpkgs-ruby.cachix.org-1:vrcdi50fTolOxWCZZkw0jakOnUI1T19oYJ+PRYdK4SM=";
+    extra-substituters = "https://nixpkgs-ruby.cachix.org";
+    extra-trusted-public-keys =
+      "nixpkgs-ruby.cachix.org-1:vrcdi50fTolOxWCZZkw0jakOnUI1T19oYJ+PRYdK4SM=";
   };
 
   inputs = {
@@ -20,7 +20,7 @@
     bob-ruby.inputs.nixpkgs.follows = "nixpkgs";
   };
 
-  outputs = { self, nixpkgs, fu, ruby-nix, bob-ruby }:
+  outputs = { self, nixpkgs, fu, ruby-nix, bundix, bob-ruby }:
     with fu.lib;
     eachDefaultSystem (system:
       let
@@ -41,6 +41,7 @@
         # See available versions here: https://github.com/bobvanderlinden/nixpkgs-ruby/blob/master/ruby/versions.json
         ruby = pkgs."ruby-3.2";
 
+        bundixcli = bundix.packages.${system}.default;
       in rec {
         inherit (rubyNix {
           inherit gemset ruby;
@@ -52,7 +53,7 @@
         devShells = rec {
           default = dev;
           dev = pkgs.mkShell {
-            buildInputs = [ env ruby-nix.bundix ]
+            buildInputs = [ env bundixcli ]
               ++ (with pkgs; [ nodejs-19_x yarn rufo ]);
           };
         };

--- a/flake.nix
+++ b/flake.nix
@@ -1,19 +1,9 @@
 {
   description = "Nix function(s) for creating ruby environments";
 
-  inputs = {
-    nixpkgs.url = "nixpkgs";
+  inputs = { nixpkgs.url = "nixpkgs"; };
 
-    # a fork that supports platform dependant gem
-    bundix = {
-      url = "github:sagittaros/bundix/main";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
-  };
-
-  outputs = { self, nixpkgs, bundix }: {
-    inherit bundix;
-
+  outputs = { self, nixpkgs }: {
     lib = import ./.;
 
     # preset gemsets

--- a/flake.nix
+++ b/flake.nix
@@ -12,7 +12,9 @@
   };
 
   outputs = { self, nixpkgs, bundix }: {
-    lib = import ./. bundix;
+    inherit bundix;
+
+    lib = import ./.;
 
     # preset gemsets
     presets = { devmode = import ./presets/devmode/gemset.nix; };
@@ -32,6 +34,6 @@
         system = "x86_64-linux";
         overlays = [ (import ./modules/overlays/ruby-overlay.nix) ];
       };
-    in import ./shell.nix { inherit pkgs bundix; };
+    in import ./shell.nix pkgs;
   };
 }

--- a/modules/ruby-env/default.nix
+++ b/modules/ruby-env/default.nix
@@ -1,14 +1,12 @@
-{ stdenv, lib, my, bundix, buildEnv, name, ... }@args:
+{ stdenv, lib, my, buildEnv, name, ... }@args:
 
 let
   rubyEnv = import ./ruby-env.nix args;
 
-  extras = [ bundix ];
-
   # useful for development
   env = buildEnv {
     inherit name;
-    paths = [ rubyEnv (lib.lowPrio rubyEnv.ruby) ] ++ extras;
+    paths = [ rubyEnv (lib.lowPrio rubyEnv.ruby) ];
     pathsToLink = [ "/" ];
     passthru = { ruby = rubyEnv.ruby; };
     meta = { platforms = rubyEnv.meta.platforms; };

--- a/shell.nix
+++ b/shell.nix
@@ -1,6 +1,6 @@
-{ pkgs, bundix }:
+pkgs:
 let
-  rubyNix = (import ./default.nix bundix) pkgs;
+  rubyNix = import ./default.nix pkgs;
   inherit (rubyNix {
     name = "rubynix-test";
     gemset = ./tests/tiny_app/gemset.nix;


### PR DESCRIPTION
Currently, bundix is incorporate into buildEnv's path, which is bad because it causes higher chance of path collisions. 