### PR TITLE
Always apply specified gemConfig for targets

### DIFF
--- a/modules/gems/expand.nix
+++ b/modules/gems/expand.nix
@@ -18,7 +18,7 @@ rec {
     attrs:
     let
       f = gemConfig.${attrs.gemName};
-      apply = (gemConfig ? ${attrs.gemName}) && attrs.compile;
+      apply = (gemConfig ? ${attrs.gemName});
     in
     if apply then attrs // f attrs else attrs;
 


### PR DESCRIPTION
I don't think this is the ideal fix, but I ran into an issue where I
needed to supply other libs to buildInputs for autopatchelf (it was
missing libmusl for libdatadog for my case).

The applyConfig would only apply my gemConfig changes if it intended to
compile them, which looks to be entirely dependent on if there are
multiple targets for the same gem.
